### PR TITLE
[batch] 정산 취소 API

### DIFF
--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchProcessor.kt
@@ -4,6 +4,7 @@ import gogo.gogobetting.domain.batch.root.persistence.Batch
 import gogo.gogobetting.domain.batch.root.persistence.BatchRepository
 import gogo.gogobetting.domain.betting.root.persistence.BettingRepository
 import org.springframework.stereotype.Component
+import java.time.LocalDateTime
 
 @Component
 class BatchProcessor(
@@ -12,8 +13,8 @@ class BatchProcessor(
 ) {
 
     fun cancel(batch: Batch) {
-        batch.cancel()
-        batchRepository.save(batch)
+        val now = LocalDateTime.now()
+        batchRepository.cancelById(batch.id, now)
         val cancelBettingIds = bettingRepository.findAllByMatchId(batch.matchId)
         bettingRepository.cancelledBatchResult(cancelBettingIds.map { it.id })
     }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchProcessor.kt
@@ -1,0 +1,22 @@
+package gogo.gogobetting.domain.batch.root.application
+
+import gogo.gogobetting.domain.batch.root.persistence.Batch
+import gogo.gogobetting.domain.batch.root.persistence.BatchRepository
+import gogo.gogobetting.domain.betting.root.persistence.BettingRepository
+import org.springframework.stereotype.Component
+
+@Component
+class BatchProcessor(
+    private val batchRepository: BatchRepository,
+    private val bettingRepository: BettingRepository
+) {
+
+    fun cancel(batch: Batch) {
+        batchRepository.deleteCancelledBatchDetail(batch.id)
+        batch.cancel()
+        batchRepository.save(batch)
+        val deleteBettingIds = bettingRepository.findAllByMatchId(batch.matchId)
+        bettingRepository.deleteCancelledBatchResult(deleteBettingIds.map { it.id })
+    }
+
+}

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchProcessor.kt
@@ -14,8 +14,8 @@ class BatchProcessor(
     fun cancel(batch: Batch) {
         batch.cancel()
         batchRepository.save(batch)
-        val deleteBettingIds = bettingRepository.findAllByMatchId(batch.matchId)
-        bettingRepository.cancelledBatchResult(deleteBettingIds.map { it.id })
+        val cancelBettingIds = bettingRepository.findAllByMatchId(batch.matchId)
+        bettingRepository.cancelledBatchResult(cancelBettingIds.map { it.id })
     }
 
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchProcessor.kt
@@ -12,11 +12,10 @@ class BatchProcessor(
 ) {
 
     fun cancel(batch: Batch) {
-        batchRepository.deleteCancelledBatchDetail(batch.id)
         batch.cancel()
         batchRepository.save(batch)
         val deleteBettingIds = bettingRepository.findAllByMatchId(batch.matchId)
-        bettingRepository.deleteCancelledBatchResult(deleteBettingIds.map { it.id })
+        bettingRepository.cancelledBatchResult(deleteBettingIds.map { it.id })
     }
 
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchService.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchService.kt
@@ -4,4 +4,5 @@ import gogo.gogobetting.domain.batch.root.application.dto.BatchDto
 
 interface BatchService {
     fun batch(matchId: Long, dto: BatchDto)
+    fun cancel(matchId: Long)
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchServiceImpl.kt
@@ -6,6 +6,7 @@ import org.springframework.batch.core.Job
 import org.springframework.batch.core.JobParametersBuilder
 import org.springframework.batch.core.launch.JobLauncher
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 @Service
@@ -13,6 +14,7 @@ class BatchServiceImpl(
     private val jobLauncher: JobLauncher,
     private val job: Job,
     private val batchReader: BatchReader,
+    private val batchProcessor: BatchProcessor,
     private val batchValidator: BatchValidator,
     private val userUtil: UserContextUtil
 ) : BatchService {
@@ -37,6 +39,14 @@ class BatchServiceImpl(
 
         jobLauncher.run(job, jobParameters)
 
+    }
+
+    @Transactional
+    override fun cancel(matchId: Long) {
+        // 동시성 처리 필요
+        val studentId = userUtil.getCurrentStudent().studentId
+        val batch = batchValidator.cancelValid(matchId, studentId)
+        batchProcessor.cancel(batch)
     }
 
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchServiceImpl.kt
@@ -1,10 +1,12 @@
 package gogo.gogobetting.domain.batch.root.application
 
 import gogo.gogobetting.domain.batch.root.application.dto.BatchDto
+import gogo.gogobetting.domain.batch.root.event.BatchCancelEvent
 import gogo.gogobetting.global.util.UserContextUtil
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.JobParametersBuilder
 import org.springframework.batch.core.launch.JobLauncher
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -16,7 +18,8 @@ class BatchServiceImpl(
     private val batchReader: BatchReader,
     private val batchProcessor: BatchProcessor,
     private val batchValidator: BatchValidator,
-    private val userUtil: UserContextUtil
+    private val userUtil: UserContextUtil,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) : BatchService {
 
     override fun batch(matchId: Long, dto: BatchDto) {
@@ -47,6 +50,13 @@ class BatchServiceImpl(
         val studentId = userUtil.getCurrentStudent().studentId
         val batch = batchValidator.cancelValid(matchId, studentId)
         batchProcessor.cancel(batch)
+
+        applicationEventPublisher.publishEvent(
+            BatchCancelEvent(
+                id = UUID.randomUUID().toString(),
+                batchId = batch.id
+            )
+        )
     }
 
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchServiceImpl.kt
@@ -42,6 +42,8 @@ class BatchServiceImpl(
 
         jobLauncher.run(job, jobParameters)
 
+        throw RuntimeException()
+
     }
 
     @Transactional
@@ -54,7 +56,8 @@ class BatchServiceImpl(
         applicationEventPublisher.publishEvent(
             BatchCancelEvent(
                 id = UUID.randomUUID().toString(),
-                batchId = batch.id
+                batchId = batch.id,
+                matchId = matchId,
             )
         )
     }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchValidator.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchValidator.kt
@@ -30,7 +30,7 @@ class BatchValidator(
             throw BettingException("Duplicate Batch, Match Id: $matchId", HttpStatus.BAD_REQUEST.value())
         }
 
-        val cancelBatch = batchRepository.findByMatchIdAndIsCancelledTrueOrderByCancelTimeDesc(matchId)
+        val cancelBatch = batchRepository.findByMatchIdAndIsCancelledTrueOrderByCancelTimeDesc(matchId).firstOrNull()
         val now = LocalDateTime.now()
         val waitMinute = 3L
         if (
@@ -40,7 +40,7 @@ class BatchValidator(
             throw BettingException(
                     "정산이 취소되었다면 ${waitMinute}분 후에 다시 정산이 가능합니다. " +
                     "Match Id: $matchId, " +
-                    "남은 시간: ${now.minute - cancelBatch.cancelTime!!.plusMinutes(waitMinute).minute}분"
+                    "남은 시간: ${cancelBatch.cancelTime!!.plusMinutes(waitMinute).minute - now.minute}분"
                 ,HttpStatus.FORBIDDEN.value())
         }
     }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchValidator.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchValidator.kt
@@ -1,8 +1,11 @@
 package gogo.gogobetting.domain.batch.root.application
 
+import gogo.gogobetting.domain.batch.root.persistence.Batch
 import gogo.gogobetting.domain.batch.root.persistence.BatchRepository
 import gogo.gogobetting.global.error.BettingException
 import gogo.gogobetting.global.internal.stage.api.StageApi
+import gogo.gogobetting.global.internal.stage.stub.MatchApiInfo
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
@@ -15,6 +18,8 @@ class BatchValidator(
 
     fun valid(matchId: Long, studentId: Long) {
         val matchDto = stageApi.matchApiInfo(matchId)
+
+        isMaintainer(matchDto, studentId, matchId)
 
         if (LocalDateTime.now().isBefore(matchDto.endDate)) {
             throw BettingException("Match Is Not End, Match Id: $matchId", HttpStatus.BAD_REQUEST.value())
@@ -38,11 +43,36 @@ class BatchValidator(
                     "남은 시간: ${now.minute - cancelBatch.cancelTime!!.plusMinutes(waitMinute).minute}분"
                 ,HttpStatus.FORBIDDEN.value())
         }
+    }
 
+    fun cancelValid(matchId: Long, studentId: Long): Batch {
+        val matchDto = stageApi.matchApiInfo(matchId)
+
+        isMaintainer(matchDto, studentId, matchId)
+
+        val batch = batchRepository.findByMatchIdAndIsCancelledFalse(matchId)
+            ?: throw BettingException("Not Found Batch, Match Id: $matchId", HttpStatus.NOT_FOUND.value())
+
+        val now = LocalDateTime.now()
+        if (now.isAfter(batch.endTime!!.plusMinutes(5))) {
+            throw BettingException("정산 이후 5분이 지난 후에는 정산 취소가 불가능합니다.", HttpStatus.FORBIDDEN.value())
+        }
+
+        return batch
+    }
+
+    private fun isMaintainer(
+        matchDto: MatchApiInfo,
+        studentId: Long,
+        matchId: Long
+    ) {
         val isMaintainer = matchDto.stage.maintainers
             .any { id -> id == studentId }
         if (isMaintainer.not()) {
-            throw BettingException("Not Maintainer, Student Id: $studentId, Match Id: $matchId", HttpStatus.BAD_REQUEST.value())
+            throw BettingException(
+                "Not Maintainer, Student Id: $studentId, Match Id: $matchId",
+                HttpStatus.BAD_REQUEST.value()
+            )
         }
     }
 

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchValidator.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchValidator.kt
@@ -71,7 +71,7 @@ class BatchValidator(
         if (isMaintainer.not()) {
             throw BettingException(
                 "Not Maintainer, Student Id: $studentId, Match Id: $matchId",
-                HttpStatus.BAD_REQUEST.value()
+                HttpStatus.FORBIDDEN.value()
             )
         }
     }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/listener/BatchApplicationEventListener.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/listener/BatchApplicationEventListener.kt
@@ -1,5 +1,6 @@
 package gogo.gogobetting.domain.batch.root.application.listener
 
+import gogo.gogobetting.domain.batch.root.event.BatchCancelEvent
 import gogo.gogobetting.domain.batch.root.event.MatchBatchEvent
 import gogo.gogobetting.global.kafka.publisher.BatchPublisher
 import org.slf4j.LoggerFactory
@@ -19,6 +20,14 @@ class BatchApplicationEventListener(
         with(event) {
             log.info("published betting batch application event: {}", id)
             batchPublisher.publishBettingBatchEvent(event)
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun batchCancelEvent(event: BatchCancelEvent) {
+        with(event) {
+            log.info("published batch cancel application event: {}", id)
+            batchPublisher.publishBatchCancelEvent(event)
         }
     }
 

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/event/BatchCancelEvent.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/event/BatchCancelEvent.kt
@@ -2,5 +2,6 @@ package gogo.gogobetting.domain.batch.root.event
 
 data class BatchCancelEvent(
     val id: String,
-    val batchId: Long
+    val batchId: Long,
+    val matchId: Long,
 )

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/event/BatchCancelEvent.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/event/BatchCancelEvent.kt
@@ -1,0 +1,6 @@
+package gogo.gogobetting.domain.batch.root.event
+
+data class BatchCancelEvent(
+    val id: String,
+    val batchId: Long
+)

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/Batch.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/Batch.kt
@@ -41,6 +41,11 @@ class Batch(
         this.cancelTime = LocalDateTime.now()
     }
 
+    fun rollbackCancel() {
+        this.isCancelled = false
+        this.cancelTime = null
+    }
+
     companion object {
 
         fun of(matchId: Long, studentId: Long, startTime: LocalDateTime, endTime: LocalDateTime?) = Batch(

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/Batch.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/Batch.kt
@@ -27,6 +27,9 @@ class Batch(
     @Column(name = "is_cancelled", nullable = false)
     var isCancelled: Boolean,
 
+    @Column(name = "cancel_time", nullable = true)
+    var cancelTime: LocalDateTime? = null,
+
 ) {
 
     fun updateEndTime() {
@@ -35,6 +38,7 @@ class Batch(
 
     fun failed() {
         this.isCancelled = true
+        this.cancelTime = LocalDateTime.now()
     }
 
     companion object {

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/Batch.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/Batch.kt
@@ -36,7 +36,7 @@ class Batch(
         this.endTime = LocalDateTime.now()
     }
 
-    fun failed() {
+    fun cancel() {
         this.isCancelled = true
         this.cancelTime = LocalDateTime.now()
     }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
@@ -9,7 +9,7 @@ interface BatchRepository: JpaRepository<Batch, Long> {
 
     fun findByMatchIdAndIsCancelledFalse(matchId: Long): Batch?
 
-    fun findByMatchIdAndIsCancelledTrueOrderByCancelTimeDesc(matchId: Long): Batch?
+    fun findByMatchIdAndIsCancelledTrueOrderByCancelTimeDesc(matchId: Long): List<Batch>
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM BatchDetail bd WHERE bd.batchId = :batchId")

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
@@ -3,6 +3,7 @@ package gogo.gogobetting.domain.batch.root.persistence
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
 
 interface BatchRepository: JpaRepository<Batch, Long> {
     fun existsByMatchIdAndIsCancelledFalse(matchId: Long): Boolean
@@ -12,6 +13,6 @@ interface BatchRepository: JpaRepository<Batch, Long> {
     fun findByMatchIdAndIsCancelledTrueOrderByCancelTimeDesc(matchId: Long): List<Batch>
 
     @Modifying(clearAutomatically = true)
-    @Query("DELETE FROM BatchDetail bd WHERE bd.batchId = :batchId")
-    fun deleteCancelledBatchDetail(batchId: Long)
+    @Query("UPDATE Batch b SET b.isCancelled = true, b.cancelTime = :now WHERE b.id = :batchId")
+    fun cancelById(batchId: Long, now: LocalDateTime)
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query
 interface BatchRepository: JpaRepository<Batch, Long> {
     fun existsByMatchIdAndIsCancelledFalse(matchId: Long): Boolean
 
+    fun findByMatchIdAndIsCancelledFalse(matchId: Long): Batch?
+
     fun findByMatchIdAndIsCancelledTrueOrderByCancelTimeDesc(matchId: Long): Batch?
 
     @Modifying(clearAutomatically = true)

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query
 interface BatchRepository: JpaRepository<Batch, Long> {
     fun existsByMatchIdAndIsCancelledFalse(matchId: Long): Boolean
 
+    fun findByMatchIdAndIsCancelledTrueOrderByCancelTimeDesc(matchId: Long): Batch?
+
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM BatchDetail bd WHERE bd.batchId = :batchId")
     fun deleteCancelledBatchDetail(batchId: Long)

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/presentation/BatchController.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/presentation/BatchController.kt
@@ -22,4 +22,12 @@ class BatchController(
         return ResponseEntity(HttpStatus.OK)
     }
 
+    @PostMapping("/batch/cancel/{match_id}")
+    fun calcel(
+        @PathVariable("match_id") matchId: Long,
+    ): ResponseEntity<Void> {
+        batchService.cancel(matchId)
+        return ResponseEntity(HttpStatus.OK)
+    }
+
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/result/persistence/BettingResult.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/result/persistence/BettingResult.kt
@@ -1,8 +1,6 @@
 package gogo.gogobetting.domain.betting.result.persistence
 
-import gogo.gogobetting.domain.betting.root.persistence.Betting
 import jakarta.persistence.*
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tbl_betting_result")
@@ -13,16 +11,24 @@ class BettingResult(
     @Column(name = "id", nullable = false)
     val id: Long = 0,
 
-    @JoinColumn(name = "betting_id", nullable = false, unique = true)
+    @JoinColumn(name = "betting_id", nullable = false)
     val bettingId: Long,
 
     @Column(name = "is_predicted", nullable = false)
     val isPredicted: Boolean,
 
     @Column(name = "earned_point", nullable = false)
-    val earnedPoint: Long
+    val earnedPoint: Long,
+
+    @Column(name = "is_cancelled", nullable = false)
+    var isCancelled: Boolean = false,
 
 ) {
+    
+    fun cancel() {
+        isCancelled = true
+    }
+
     companion object {
 
         fun of(bettingId: Long, earnedPoint: Long, isPredicted: Boolean) = BettingResult(

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingRepository.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingRepository.kt
@@ -12,5 +12,10 @@ interface BettingRepository: JpaRepository<Betting, Long>, BettingCustomReposito
     @Query("UPDATE BettingResult br SET br.isCancelled = true WHERE br.bettingId IN (:bettingIds)")
     fun cancelledBatchResult(bettingIds: List<Long>)
 
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE BettingResult br SET br.isCancelled = false WHERE br.bettingId IN (:bettingIds)")
+    fun rollbackCancelledBatchResult(bettingIds: List<Long>)
+
     fun findAllByMatchId(matchId: Long): List<Betting>
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingRepository.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingRepository.kt
@@ -9,8 +9,8 @@ interface BettingRepository: JpaRepository<Betting, Long>, BettingCustomReposito
     fun existsByMatchIdAndStudentIdAndStatus(matchId: Long, studentId: Long, status: BettingStatus): Boolean
 
     @Modifying(clearAutomatically = true)
-    @Query("DELETE FROM BettingResult br WHERE br.bettingId IN (:bettingIds)")
-    fun deleteCancelledBatchResult(bettingIds: List<Long>)
+    @Query("UPDATE BettingResult br SET br.isCancelled = true WHERE br.bettingId IN (:bettingIds)")
+    fun cancelledBatchResult(bettingIds: List<Long>)
 
     fun findAllByMatchId(matchId: Long): List<Betting>
 }

--- a/src/main/kotlin/gogo/gogobetting/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/config/SecurityConfig.kt
@@ -50,6 +50,7 @@ class SecurityConfig(
 
             // batch
             httpRequests.requestMatchers(HttpMethod.POST, "/betting/batch/{match_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+            httpRequests.requestMatchers(HttpMethod.POST, "/betting/batch/cancel/{match_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
             httpRequests.anyRequest().denyAll()
         }

--- a/src/main/kotlin/gogo/gogobetting/global/kafka/configuration/KafkaConsumerConfig.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/kafka/configuration/KafkaConsumerConfig.kt
@@ -1,6 +1,7 @@
 package gogo.gogobetting.global.kafka.configuration
 
 import gogo.gogobetting.global.kafka.consumer.BatchAdditionTempPointFailedConsumer
+import gogo.gogobetting.global.kafka.consumer.BatchCancelDeleteTempPointFailedConsumer
 import gogo.gogobetting.global.kafka.consumer.MatchBettingFailedConsumer
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
 import org.springframework.context.annotation.Bean
@@ -23,6 +24,10 @@ class KafkaConsumerConfig(
 
     @Bean
     fun batchAdditionTempPointFailedEventListenerContainerFactory(listener: BatchAdditionTempPointFailedConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =
+        makeFactory(listener)
+
+    @Bean
+    fun batchCancelDeleteTempPointFailedEventListenerContainerFactory(listener: BatchCancelDeleteTempPointFailedConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =
         makeFactory(listener)
 
     private fun makeFactory(listener: AcknowledgingMessageListener<String, String>): ConcurrentKafkaListenerContainerFactory<String, String> {

--- a/src/main/kotlin/gogo/gogobetting/global/kafka/consumer/BatchCancelDeleteTempPointFailedConsumer.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/kafka/consumer/BatchCancelDeleteTempPointFailedConsumer.kt
@@ -1,0 +1,37 @@
+package gogo.gogobetting.global.kafka.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import gogo.gogobetting.global.kafka.consumer.dto.BatchCancelDeleteTempPointFailedEvent
+import gogo.gogobetting.global.kafka.properties.KafkaTopics.BATCH_CANCEL_DELETE_TEMP_POINT_FAILED
+import gogo.gogobetting.global.saga.DeleteTempPointFailedSaga
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.listener.AcknowledgingMessageListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Service
+
+@Service
+class BatchCancelDeleteTempPointFailedConsumer(
+    private val objectMapper: ObjectMapper,
+    private val deleteTempPointFailedSaga: DeleteTempPointFailedSaga
+) : AcknowledgingMessageListener<String, String> {
+
+    private val log = LoggerFactory.getLogger(this::class.java.simpleName)
+
+    @KafkaListener(
+        topics = [BATCH_CANCEL_DELETE_TEMP_POINT_FAILED],
+        groupId = "gogo",
+        containerFactory = "batchCancelDeleteTempPointFailedEventListenerContainerFactory"
+    )
+    override fun onMessage(data: ConsumerRecord<String, String>, acknowledgment: Acknowledgment?) {
+        val (key, event) = data.key() to objectMapper.readValue(data.value(), BatchCancelDeleteTempPointFailedEvent::class.java)
+        log.info("${BATCH_CANCEL_DELETE_TEMP_POINT_FAILED}_topic, key: $key, event: $event")
+
+        deleteTempPointFailedSaga.rollbackCancelledBatch(event.batchId)
+
+        acknowledgment!!.acknowledge()
+    }
+
+
+}

--- a/src/main/kotlin/gogo/gogobetting/global/kafka/consumer/dto/BatchCancelDeleteTempPointFailedEvent.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/kafka/consumer/dto/BatchCancelDeleteTempPointFailedEvent.kt
@@ -1,0 +1,6 @@
+package gogo.gogobetting.global.kafka.consumer.dto
+
+data class BatchCancelDeleteTempPointFailedEvent(
+    val id: String,
+    val batchId: Long
+)

--- a/src/main/kotlin/gogo/gogobetting/global/kafka/properties/KafkaTopics.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/kafka/properties/KafkaTopics.kt
@@ -5,6 +5,6 @@ object KafkaTopics {
     const val MATCH_BETTING_FAILED = "match_betting_failed"
     const val MATCH_BATCH = "match_batch"
     const val BATCH_ADDITION_TEMP_POINT_FAILED = "batch_addition_temp_point_failed"
-    const val CANCEL_BATCH = "cancel_batch"
-    const val DELETE_TEMP_POINT_FAILED = "delete_temp_point_failed"
+    const val BATCH_CANCEL = "batch_cancel"
+    const val BATCH_CANCEL_DELETE_TEMP_POINT_FAILED = "batch_cancel_delete_temp_point_failed"
 }

--- a/src/main/kotlin/gogo/gogobetting/global/kafka/properties/KafkaTopics.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/kafka/properties/KafkaTopics.kt
@@ -5,4 +5,6 @@ object KafkaTopics {
     const val MATCH_BETTING_FAILED = "match_betting_failed"
     const val MATCH_BATCH = "match_batch"
     const val BATCH_ADDITION_TEMP_POINT_FAILED = "batch_addition_temp_point_failed"
+    const val CANCEL_BATCH = "cancel_batch"
+    const val DELETE_TEMP_POINT_FAILED = "delete_temp_point_failed"
 }

--- a/src/main/kotlin/gogo/gogobetting/global/kafka/publisher/BatchPublisher.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/kafka/publisher/BatchPublisher.kt
@@ -2,7 +2,7 @@ package gogo.gogobetting.global.kafka.publisher
 
 import gogo.gogobetting.domain.batch.root.event.BatchCancelEvent
 import gogo.gogobetting.domain.batch.root.event.MatchBatchEvent
-import gogo.gogobetting.global.kafka.properties.KafkaTopics.CANCEL_BATCH
+import gogo.gogobetting.global.kafka.properties.KafkaTopics.BATCH_CANCEL
 import gogo.gogobetting.global.kafka.properties.KafkaTopics.MATCH_BATCH
 import gogo.gogobetting.global.publisher.TransactionEventPublisher
 import org.springframework.stereotype.Component
@@ -29,7 +29,7 @@ class BatchPublisher(
     ) {
         val key = UUID.randomUUID().toString()
         transactionEventPublisher.publishEvent(
-            topic = CANCEL_BATCH,
+            topic = BATCH_CANCEL,
             key = key,
             event = event
         )

--- a/src/main/kotlin/gogo/gogobetting/global/kafka/publisher/BatchPublisher.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/kafka/publisher/BatchPublisher.kt
@@ -1,6 +1,8 @@
 package gogo.gogobetting.global.kafka.publisher
 
+import gogo.gogobetting.domain.batch.root.event.BatchCancelEvent
 import gogo.gogobetting.domain.batch.root.event.MatchBatchEvent
+import gogo.gogobetting.global.kafka.properties.KafkaTopics.CANCEL_BATCH
 import gogo.gogobetting.global.kafka.properties.KafkaTopics.MATCH_BATCH
 import gogo.gogobetting.global.publisher.TransactionEventPublisher
 import org.springframework.stereotype.Component
@@ -17,6 +19,17 @@ class BatchPublisher(
         val key = UUID.randomUUID().toString()
         transactionEventPublisher.publishEvent(
             topic = MATCH_BATCH,
+            key = key,
+            event = event
+        )
+    }
+
+    fun publishBatchCancelEvent(
+        event: BatchCancelEvent,
+    ) {
+        val key = UUID.randomUUID().toString()
+        transactionEventPublisher.publishEvent(
+            topic = CANCEL_BATCH,
             key = key,
             event = event
         )

--- a/src/main/kotlin/gogo/gogobetting/global/saga/AdditionTempPointFailedSaga.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/saga/AdditionTempPointFailedSaga.kt
@@ -19,11 +19,10 @@ class AdditionTempPointFailedSaga(
         val batch = (batchRepository.findByIdOrNull(batchId)
             ?: throw BettingException("Batch Not Found -- SAGA.cancelledBatch($batchId)", HttpStatus.NOT_FOUND.value()))
         batch.cancel()
+        batchRepository.save(batch)
 
         val bettings = bettingRepository.findAllByMatchId(batch.matchId)
-        bettingRepository.deleteCancelledBatchResult(bettings.map { it.id })
-        batchRepository.deleteCancelledBatchDetail(batchId)
-        batchRepository.save(batch)
+        bettingRepository.cancelledBatchResult(bettings.map { it.id })
     }
 
 }

--- a/src/main/kotlin/gogo/gogobetting/global/saga/AdditionTempPointFailedSaga.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/saga/AdditionTempPointFailedSaga.kt
@@ -18,7 +18,7 @@ class AdditionTempPointFailedSaga(
     fun cancelledBatch(batchId: Long) {
         val batch = (batchRepository.findByIdOrNull(batchId)
             ?: throw BettingException("Batch Not Found -- SAGA.cancelledBatch($batchId)", HttpStatus.NOT_FOUND.value()))
-        batch.failed()
+        batch.cancel()
 
         val bettings = bettingRepository.findAllByMatchId(batch.matchId)
         bettingRepository.deleteCancelledBatchResult(bettings.map { it.id })

--- a/src/main/kotlin/gogo/gogobetting/global/saga/DeleteTempPointFailedSaga.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/saga/DeleteTempPointFailedSaga.kt
@@ -1,0 +1,28 @@
+package gogo.gogobetting.global.saga
+
+import gogo.gogobetting.domain.batch.root.persistence.BatchRepository
+import gogo.gogobetting.domain.betting.root.persistence.BettingRepository
+import gogo.gogobetting.global.error.BettingException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class DeleteTempPointFailedSaga(
+    private val batchRepository: BatchRepository,
+    private val bettingRepository: BettingRepository,
+) {
+
+    @Transactional
+    fun rollbackCancelledBatch(batchId: Long) {
+        val batch = (batchRepository.findByIdOrNull(batchId)
+            ?: throw BettingException("Batch Not Found -- SAGA.cancelledBatch($batchId)", HttpStatus.NOT_FOUND.value()))
+        batch.rollbackCancel()
+        batchRepository.save(batch)
+
+        val cancelledBettingIds = bettingRepository.findAllByMatchId(batch.matchId)
+        bettingRepository.rollbackCancelledBatchResult(cancelledBettingIds.map { it.id })
+    }
+
+}

--- a/src/main/kotlin/gogo/gogobetting/infra/batch/listener/BatchExecutionListener.kt
+++ b/src/main/kotlin/gogo/gogobetting/infra/batch/listener/BatchExecutionListener.kt
@@ -34,7 +34,7 @@ class BatchExecutionListener(
         val batch = batchRepository.findByIdOrNull(batchId)!!
         batch.updateEndTime()
         if (jobExecution.status.isUnsuccessful) {
-            batch.failed()
+            batch.cancel()
         }
         batchRepository.save(batch)
     }


### PR DESCRIPTION
## 개요
정산 취소 API를 개발하였습니다.

## 본문
완료된 정산은 5분이 지나기 전에 취소가 가능합니다.
- 취소 요청시 tbl_batch, tbl_betting_result 테이블의 취소 상태를 나타내는 컬럼을 true로 변경합니다.
- batch_cancel 토픽에 이벤트를 발행합니다.
   - Stage 서비스에서 해당 이벤트를 컨슘하여 정산된 임시포인트를 삭제합니다.
   - 만약 임시포인트가 이미 반영되었다면, batch_cancel_delete_temp_point_failed 이밴트를 발행하여 Betting 서비스에서 정산 취소 작업을 롤백 시킵니다.

## 추가사항
정산 요청 validation 작업에서 `취소 -> 재정산`시 취소 시점을 기준으로 3분 이후에 재정산이 가능하도록 하였습니다.
-> 임시포인트 삭제, 재정산 이벤트 통신의 일관성을 보장하기 위해서