### PR TITLE
[betting] 배팅, 정산, 정산 취소 동시성 처리

### DIFF
--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchReader.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchReader.kt
@@ -15,7 +15,7 @@ class BatchReader(
     fun readBettingOdds(matchId: Long, winTeamId: Long): Double =
         bettingRepository.calcOdds(matchId, winTeamId).odds
 
-    fun readByMatchId(matchId: Long) = batchRepository.findByMatchIdAndIsCancelledFalse(matchId)
+    fun readByMatchIdForWrite(matchId: Long) = batchRepository.findByMatchIdAndIsCancelledFalse(matchId)
         ?: throw BettingException("Not Found Batch, Match Id: $matchId", HttpStatus.NOT_FOUND.value())
 
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchServiceImpl.kt
@@ -50,9 +50,8 @@ class BatchServiceImpl(
 
     @Transactional
     override fun cancel(matchId: Long) {
-        // 동시성 처리 필요
         val studentId = userUtil.getCurrentStudent().studentId
-        val batch = batchReader.readByMatchId(matchId)
+        val batch = batchReader.readByMatchIdForWrite(matchId)
         batchValidator.cancelValid(batch, matchId, studentId)
         batchProcessor.cancel(batch)
 

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchServiceImpl.kt
@@ -23,7 +23,6 @@ class BatchServiceImpl(
 ) : BatchService {
 
     override fun batch(matchId: Long, dto: BatchDto) {
-        // 동시성 처리 필요
         val studentId = userUtil.getCurrentStudent().studentId
 
         val isEmptyBetting = batchValidator.valid(matchId, studentId)

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchValidator.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchValidator.kt
@@ -8,6 +8,7 @@ import gogo.gogobetting.global.internal.stage.api.StageApi
 import gogo.gogobetting.global.internal.stage.stub.MatchApiInfo
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 @Component
@@ -17,6 +18,7 @@ class BatchValidator(
     private val bettingRepository: BettingRepository
 ) {
 
+    @Transactional
     fun valid(matchId: Long, studentId: Long): Boolean {
         val bettingCount = bettingRepository.countByMatchId(matchId)
 

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
@@ -12,6 +12,7 @@ interface BatchRepository: JpaRepository<Batch, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun existsByMatchIdAndIsCancelledFalse(matchId: Long): Boolean
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun findByMatchIdAndIsCancelledFalse(matchId: Long): Batch?
 
     fun findByMatchIdAndIsCancelledTrueOrderByCancelTimeDesc(matchId: Long): List<Batch>

--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/persistence/BatchRepository.kt
@@ -1,11 +1,15 @@
 package gogo.gogobetting.domain.batch.root.persistence
 
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import java.time.LocalDateTime
 
 interface BatchRepository: JpaRepository<Batch, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun existsByMatchIdAndIsCancelledFalse(matchId: Long): Boolean
 
     fun findByMatchIdAndIsCancelledFalse(matchId: Long): Batch?

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingServiceImpl.kt
@@ -21,7 +21,6 @@ class BettingServiceImpl(
 
     @Transactional
     override fun bet (matchId: Long, dto: BettingDto) {
-        // 동시성 처리 필요
         val student = userUtil.getCurrentStudent()
         bettingValidator.valid(matchId, student.studentId)
         val betting = bettingProcessor.save(matchId, student.studentId, dto)

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingRepository.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingRepository.kt
@@ -1,11 +1,14 @@
 package gogo.gogobetting.domain.betting.root.persistence
 
 import gogo.gogobetting.domain.betting.root.persistence.type.BettingStatus
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface BettingRepository: JpaRepository<Betting, Long>, BettingCustomRepository {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun existsByMatchIdAndStudentIdAndStatus(matchId: Long, studentId: Long, status: BettingStatus): Boolean
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)


### PR DESCRIPTION
## 개요
배팅, 정산, 정산 취소 작업의 동시성 문제를 처리하였습니다.

## 본문
- 배팅, 정산, 정산 취소 작업의 중복 조회 쿼리에 row lock을 잡아 동시성 문제를 처리하였습니다.
- row lock을 효율적으로 잡기 위해 해당 쿼리 조건 컬럼에 적절한 인덱스를 생성하였습니다. -> 노션 docs 참고