### PR TITLE
[batch] 정산 실패 이벤트 핸들링시 JPQL flush 이슈 해결

### DIFF
--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/BatchProcessor.kt
@@ -57,7 +57,7 @@ class BatchProcessor(
 
     fun cancel(batch: Batch) {
         val cancelBettingIds = bettingRepository.findAllByMatchId(batch.matchId)
-        bettingRepository.cancelledBatchResult(cancelBettingIds.map { it.id })
+        bettingRepository.cancelledBettingResult(cancelBettingIds.map { it.id })
         val now = LocalDateTime.now()
         batchRepository.cancelById(batch.id, now)
     }

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingRepository.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingRepository.kt
@@ -11,13 +11,13 @@ interface BettingRepository: JpaRepository<Betting, Long>, BettingCustomReposito
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun existsByMatchIdAndStudentIdAndStatus(matchId: Long, studentId: Long, status: BettingStatus): Boolean
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying(flushAutomatically = true)
     @Query("UPDATE BettingResult br SET br.isCancelled = true WHERE br.bettingId IN (:bettingIds)")
-    fun cancelledBatchResult(bettingIds: List<Long>)
+    fun cancelledBettingResult(bettingIds: List<Long>)
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE BettingResult br SET br.isCancelled = false WHERE br.bettingId IN (:bettingIds)")
-    fun rollbackCancelledBatchResult(bettingIds: List<Long>)
+    fun rollbackCancelledBettingResult(bettingIds: List<Long>)
 
     fun findAllByMatchId(matchId: Long): List<Betting>
 

--- a/src/main/kotlin/gogo/gogobetting/global/saga/AdditionTempPointFailedSaga.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/saga/AdditionTempPointFailedSaga.kt
@@ -22,7 +22,7 @@ class AdditionTempPointFailedSaga(
         batchRepository.save(batch)
 
         val bettings = bettingRepository.findAllByMatchId(batch.matchId)
-        bettingRepository.cancelledBatchResult(bettings.map { it.id })
+        bettingRepository.cancelledBettingResult(bettings.map { it.id })
     }
 
 }

--- a/src/main/kotlin/gogo/gogobetting/global/saga/DeleteTempPointFailedSaga.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/saga/DeleteTempPointFailedSaga.kt
@@ -20,7 +20,7 @@ class DeleteTempPointFailedSaga(
             ?: throw BettingException("Batch Not Found -- SAGA.cancelledBatch($batchId)", HttpStatus.NOT_FOUND.value()))
 
         val cancelledBettingIds = bettingRepository.findAllByMatchId(batch.matchId).map { it.id }
-        bettingRepository.rollbackCancelledBatchResult(cancelledBettingIds)
+        bettingRepository.rollbackCancelledBettingResult(cancelledBettingIds)
         batchRepository.rollBackCancelledById(batchId)
     }
 


### PR DESCRIPTION
## 개요
- Stage Service에서 정산 후 포인트 차감에 실패했다면 -> Betting Service 정산 실패 이벤트를 핸들링합니다.
- 하지만 정산 실패 이벤트 핸들링은 되었지만 정산 취소가 되지 않은 문제가 발생합니다.

## 본문

정산 실패 이벤트 핸들링 SAGA 서비스는 아래와 같은 작업을 처리합니다.

```kotlin
val batch = // 정산조회
batch.cancel()
batchRepository.save(batch)

val bettings = // 정산에 영향을 받은 배팅 list 조회

// 배팅 list를 순회하며 취소 처리: 
// 해당 메서드는 @Modifying(clearAutomatically = true) 설정됨
bettingRepository.cancelledBettingResult(bettings.map { it.id })
```

- 정산을 조회하여 취소 처리 후 save 메서드를 호출합니다.
- 그리고 아래에 정산을 영향받은 배팅들을 조회하여 JPQL을 날려 취소 처리합니다. 해당 JPQL은 clearAutomatically 옵션이 켜져있습니다.
- 하지만 jpa flush mode는 default AUTO 모드입니다. 해당 모드는 JPQL 실행 전 영속성 컨텍스트에 해당 JPQL에 연관이 있는 영속성 컨텍스트의 엔티티만 flush를 호출합니다.
- 하지만 정산 엔티티는 해당 JPQL에 직접적인 연관이 없기 때문에 정산 처리는 flush 되지 않고 배팅들의 취소처리 이후에 clearAutomatically 옵션에 의해 영속성 컨텍스트가 삭제되어 정산 취소가 반영되지 않았습니다.