### PR TITLE
[betting] 학생 ID, 매치ID들로 총 배팅 포인트 확인하기 Internal API

### DIFF
--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingMapper.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingMapper.kt
@@ -1,10 +1,7 @@
 package gogo.gogobetting.domain.betting.root.application
 
 import gogo.gogobetting.domain.betting.result.persistence.BettingResultRepository
-import gogo.gogobetting.domain.betting.root.application.dto.BettingBundleDto
-import gogo.gogobetting.domain.betting.root.application.dto.BettingBundleInfoDto
-import gogo.gogobetting.domain.betting.root.application.dto.BettingInfoDto
-import gogo.gogobetting.domain.betting.root.application.dto.BettingResultInfoDto
+import gogo.gogobetting.domain.betting.root.application.dto.*
 import gogo.gogobetting.domain.betting.root.persistence.Betting
 import org.springframework.stereotype.Component
 
@@ -35,5 +32,9 @@ class BettingMapper(
         return BettingBundleDto(bundleInfo)
     }
 
+    fun mapBettingPoint(bettingList: List<Betting>): TotalBettingPointDto =
+        TotalBettingPointDto(
+            bettingPoint = bettingList.sumOf { it.point }
+        )
 
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingReader.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingReader.kt
@@ -12,4 +12,7 @@ class BettingReader(
     fun readBundleInfo(matchIds: List<Long>, studentId: Long): List<Betting> =
         bettingRepository.findBettingBundleInfo(matchIds, studentId)
 
+    fun readBundleActiveInfo(matchIds: List<Long>, studentId: Long): List<Betting> =
+        bettingRepository.findBettingBundleInfo(matchIds, studentId)
+
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingReader.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingReader.kt
@@ -13,6 +13,6 @@ class BettingReader(
         bettingRepository.findBettingBundleInfo(matchIds, studentId)
 
     fun readBundleActiveInfo(matchIds: List<Long>, studentId: Long): List<Betting> =
-        bettingRepository.findBettingBundleInfo(matchIds, studentId)
+        bettingRepository.findBettingActiveBundleInfo(matchIds, studentId)
 
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingService.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingService.kt
@@ -2,8 +2,10 @@ package gogo.gogobetting.domain.betting.root.application
 
 import gogo.gogobetting.domain.betting.root.application.dto.BettingBundleDto
 import gogo.gogobetting.domain.betting.root.application.dto.BettingDto
+import gogo.gogobetting.domain.betting.root.application.dto.TotalBettingPointDto
 
 interface BettingService {
     fun bet(matchId: Long, dto: BettingDto)
     fun bundle(matchIds: List<Long>, studentId: Long): BettingBundleDto
+    fun totalBettingPoint(matchIds: List<Long>, studentId: Long): TotalBettingPointDto
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/BettingServiceImpl.kt
@@ -2,6 +2,7 @@ package gogo.gogobetting.domain.betting.root.application
 
 import gogo.gogobetting.domain.betting.root.application.dto.BettingBundleDto
 import gogo.gogobetting.domain.betting.root.application.dto.BettingDto
+import gogo.gogobetting.domain.betting.root.application.dto.TotalBettingPointDto
 import gogo.gogobetting.domain.betting.root.event.MatchBettingEvent
 import gogo.gogobetting.global.util.UserContextUtil
 import org.springframework.context.ApplicationEventPublisher
@@ -41,6 +42,12 @@ class BettingServiceImpl(
     override fun bundle(matchIds: List<Long>, studentId: Long): BettingBundleDto {
         val bettings = bettingReader.readBundleInfo(matchIds, studentId)
         return bettingMapper.mapBundle(bettings)
+    }
+
+    @Transactional(readOnly = true)
+    override fun totalBettingPoint(matchIds: List<Long>, studentId: Long): TotalBettingPointDto {
+        val bettings = bettingReader.readBundleActiveInfo(matchIds, studentId)
+        return bettingMapper.mapBettingPoint(bettings)
     }
 
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/dto/BettingDto.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/application/dto/BettingDto.kt
@@ -34,3 +34,6 @@ data class BettingResultInfoDto(
     val earnedPoint: Long,
 )
 
+data class TotalBettingPointDto(
+    val bettingPoint: Long,
+)

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingCustomRepository.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingCustomRepository.kt
@@ -5,4 +5,5 @@ import gogo.gogobetting.domain.betting.root.application.dto.MatchOddsDto
 interface BettingCustomRepository {
     fun calcOdds(matchId: Long, winTeamId: Long): MatchOddsDto
     fun findBettingBundleInfo(matchIds: List<Long>, studentId: Long): List<Betting>
+    fun findBettingActiveBundleInfo(matchIds: List<Long>, studentId: Long): List<Betting>
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingCustomRepositoryImpl.kt
@@ -65,13 +65,12 @@ class BettingCustomRepositoryImpl(
             .leftJoin(bettingResult)
             .on(
                 bettingResult.bettingId.eq(betting.id)
-                    .and(bettingResult.isCancelled.eq(false))
             )
             .where(
                 betting.matchId.`in`(matchIds)
                     .and(betting.studentId.eq(studentId))
                     .and(betting.status.eq(CONFIRMED))
-                    .and(bettingResult.isNotNull)
+                    .and(bettingResult.isNull)
             )
             .fetch()
 

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/persistence/BettingCustomRepositoryImpl.kt
@@ -59,4 +59,20 @@ class BettingCustomRepositoryImpl(
             )
             .fetch()
 
+    override fun findBettingActiveBundleInfo(matchIds: List<Long>, studentId: Long): List<Betting> =
+        queryFactory
+            .selectFrom(betting)
+            .leftJoin(bettingResult)
+            .on(
+                bettingResult.bettingId.eq(betting.id)
+                    .and(bettingResult.isCancelled.eq(false))
+            )
+            .where(
+                betting.matchId.`in`(matchIds)
+                    .and(betting.studentId.eq(studentId))
+                    .and(betting.status.eq(CONFIRMED))
+                    .and(bettingResult.isNotNull)
+            )
+            .fetch()
+
 }

--- a/src/main/kotlin/gogo/gogobetting/domain/betting/root/presentation/BettingController.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/betting/root/presentation/BettingController.kt
@@ -3,6 +3,7 @@ package gogo.gogobetting.domain.betting.root.presentation
 import gogo.gogobetting.domain.betting.root.application.BettingService
 import gogo.gogobetting.domain.betting.root.application.dto.BettingBundleDto
 import gogo.gogobetting.domain.betting.root.application.dto.BettingDto
+import gogo.gogobetting.domain.betting.root.application.dto.TotalBettingPointDto
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotNull
 import org.springframework.http.HttpStatus
@@ -30,6 +31,15 @@ class BettingController(
         @RequestParam @Valid @NotNull studentId: Long
     ): ResponseEntity<BettingBundleDto> {
         val response = bettingService.bundle(matchIds, studentId)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/point")
+    fun totalBettingPoint(
+        @RequestParam @Valid @NotNull matchIds: List<Long>,
+        @RequestParam @Valid @NotNull studentId: Long
+    ): ResponseEntity<TotalBettingPointDto> {
+        val response = bettingService.totalBettingPoint(matchIds, studentId)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/gogo/gogobetting/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogobetting/global/config/SecurityConfig.kt
@@ -63,6 +63,7 @@ class SecurityConfig(
 
             // server to server
             httpRequests.requestMatchers(HttpMethod.GET, "/betting/bundle").access { _, context -> hasIpAddress(context) }
+            httpRequests.requestMatchers(HttpMethod.GET, "/betting/point").access { _, context -> hasIpAddress(context) }
 
             httpRequests.anyRequest().denyAll()
         }


### PR DESCRIPTION
## 개요
학생 ID, 매치ID들로 총 배팅 포인트 확인하기 Internal API를 개발하였습니다.

## 본문
- 학생 ID, 매치ID들을 요청받아 정산되지 않은 배팅들의 포인트 합을 반환합니다.