### PR TITLE
[hotfix] 매치 정산 일괄 처리 수정

### DIFF
--- a/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/listener/BatchApplicationEventListener.kt
+++ b/src/main/kotlin/gogo/gogobetting/domain/batch/root/application/listener/BatchApplicationEventListener.kt
@@ -1,7 +1,6 @@
 package gogo.gogobetting.domain.batch.root.application.listener
 
 import gogo.gogobetting.domain.batch.root.event.BatchCancelEvent
-import gogo.gogobetting.domain.batch.root.event.MatchBatchEvent
 import gogo.gogobetting.global.kafka.publisher.BatchPublisher
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -14,14 +13,6 @@ class BatchApplicationEventListener(
 ) {
 
     private val log = LoggerFactory.getLogger(this::class.java.simpleName)
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun bettingBatchEvent(event: MatchBatchEvent) {
-        with(event) {
-            log.info("published betting batch application event: {}", id)
-            batchPublisher.publishBettingBatchEvent(event)
-        }
-    }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun batchCancelEvent(event: BatchCancelEvent) {

--- a/src/main/kotlin/gogo/gogobetting/infra/batch/service/BettingWriter.kt
+++ b/src/main/kotlin/gogo/gogobetting/infra/batch/service/BettingWriter.kt
@@ -73,8 +73,7 @@ class BettingWriter(
 
         val successList = accumulatedItems.filter { it.isPredicted }
             .map {
-                val studentId = bettingRepository.findByIdOrNull(it.bettingId)?.studentId
-                    ?: error("학생을 찾을 수 없습니다. bettingId=${it.bettingId}")
+                val studentId = bettingRepository.findByIdOrNull(it.bettingId)!!.studentId
                 StudentBettingDto(studentId, it.earnedPoint)
             }
 

--- a/src/main/kotlin/gogo/gogobetting/infra/batch/service/BettingWriter.kt
+++ b/src/main/kotlin/gogo/gogobetting/infra/batch/service/BettingWriter.kt
@@ -8,7 +8,10 @@ import gogo.gogobetting.domain.batch.root.persistence.BatchRepository
 import gogo.gogobetting.domain.betting.result.persistence.BettingResult
 import gogo.gogobetting.domain.betting.result.persistence.BettingResultRepository
 import gogo.gogobetting.domain.betting.root.persistence.BettingRepository
+import gogo.gogobetting.global.kafka.publisher.BatchPublisher
+import org.slf4j.LoggerFactory
 import org.springframework.batch.core.StepExecution
+import org.springframework.batch.core.annotation.AfterStep
 import org.springframework.batch.core.annotation.BeforeStep
 import org.springframework.batch.core.configuration.annotation.StepScope
 import org.springframework.batch.item.Chunk
@@ -27,6 +30,7 @@ class BettingWriter(
     private val batchRepository: BatchRepository,
     private val bettingRepository: BettingRepository,
     private val applicationEventPublisher: ApplicationEventPublisher,
+    private val batchPublisher: BatchPublisher,
 ) : ItemWriter<BettingResult> {
 
     @Value("#{jobParameters['matchId']}")
@@ -42,17 +46,22 @@ class BettingWriter(
     private val bTeamScore: Int = 0
 
     private var batchId: Long = 0
+    private val accumulatedItems = mutableListOf<BettingResult>()
+
+    private val log = LoggerFactory.getLogger(this::class.java.simpleName)
 
     @BeforeStep
     fun beforeStep(stepExecution: StepExecution) {
         val jobExecution = stepExecution.jobExecution
+        accumulatedItems.clear()
         batchId = jobExecution.executionContext["batchId"]!! as Long
     }
 
-    override fun write(items: Chunk<out BettingResult>) {
-        bettingResultRepository.saveAll(items)
-
+    @AfterStep
+    fun afterStep(stepExecution: StepExecution) {
+        println(">>>>> afterStep called")
         val batch = batchRepository.findByIdOrNull(batchId)!!
+
         batchDetailRepository.save(
             BatchDetail.of(
                 batchId = batch.id,
@@ -62,24 +71,29 @@ class BettingWriter(
             )
         )
 
-        val successList = items.filter { it.isPredicted }
-            .map { StudentBettingDto(
-                    bettingRepository.findByIdOrNull(it.bettingId)!!.studentId,
-                    it.earnedPoint
-                )
+        val successList = accumulatedItems.filter { it.isPredicted }
+            .map {
+                val studentId = bettingRepository.findByIdOrNull(it.bettingId)?.studentId
+                    ?: error("학생을 찾을 수 없습니다. bettingId=${it.bettingId}")
+                StudentBettingDto(studentId, it.earnedPoint)
             }
 
-        applicationEventPublisher.publishEvent(
-            MatchBatchEvent(
-                id = UUID.randomUUID().toString(),
-                batchId = batchId,
-                matchId = matchId,
-                victoryTeamId = winTeamId,
-                aTeamScore = aTeamScore,
-                bTeamScore = bTeamScore,
-                students = successList
-            )
+        val event = MatchBatchEvent(
+            id = UUID.randomUUID().toString(),
+            batchId = batchId,
+            matchId = matchId,
+            victoryTeamId = winTeamId,
+            aTeamScore = aTeamScore,
+            bTeamScore = bTeamScore,
+            students = successList
         )
 
+        log.info("published betting batch application event: {}", event.id)
+        batchPublisher.publishBettingBatchEvent(event)
+    }
+
+    override fun write(items: Chunk<out BettingResult>) {
+        bettingResultRepository.saveAll(items)
+        accumulatedItems.addAll(items)
     }
 }

--- a/src/main/kotlin/gogo/gogobetting/infra/batch/service/BettingWriter.kt
+++ b/src/main/kotlin/gogo/gogobetting/infra/batch/service/BettingWriter.kt
@@ -59,7 +59,6 @@ class BettingWriter(
 
     @AfterStep
     fun afterStep(stepExecution: StepExecution) {
-        println(">>>>> afterStep called")
         val batch = batchRepository.findByIdOrNull(batchId)!!
 
         batchDetailRepository.save(


### PR DESCRIPTION
## 수정 내용
- 현재 정산시 50개의 청크 단위로 배팅 row를 읽고 처리합니다.
- 하지만 processor 에서 하나의 청크마다 tbl_batch_detail 저장과 이벤트 발행을 하고 있어, 50개 이상의 배팅 정보가 있다면 1번 저장되고 발행되어야하는 작업들이 N번 발생할 수 있습니다.
- 일괄 처리해야하는 정보를 필드에 저장하고 @AfterStep을 감싼 메서드를 만들어 일괄적으로 단 한번 처리하도록 수정했습니다.
- @StepScope 의 클래스는 호출시마다 새로운 인스턴스를 만들기 때문에 필드 동시성 문제가 발생하지 않기 때문에 필드에 데이터를 저장하였습니다. 이후 개선이 필요합니다.
- @AfterStep의 메서드에서 스프링 이벤트를 발행해도 핸들링 되지 않아 직접적으로 카프카 퍼블리셔를 실행하였습니다. 이후 개선이 필요합니다.